### PR TITLE
fix: Define a ordem de rotação da câmera para 'YXZ'

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -345,6 +345,9 @@
             playerBody.updateMassProperties();
             world.addBody(playerBody);
 
+            // Corrige o problema de "visão diagonal" definindo a ordem de rotação
+            camera.rotation.order = 'YXZ';
+
             // Adiciona um listener para colisões para verificar se pode pular
             playerBody.addEventListener("collide", (e) => {
                 // Checa se a colisão ocorreu com algo abaixo do jogador


### PR DESCRIPTION
Este commit corrige um problema em que o movimento horizontal do mouse causava um ligeiro movimento diagonal na câmera. Isso ocorria porque a ordem de rotação dos eixos não estava explicitamente definida.

A solução foi definir `camera.rotation.order = 'YXZ'`, o que garante que a rotação horizontal (Y, yaw) seja processada antes da rotação vertical (X, pitch). Esta é a abordagem padrão para controles de câmera em primeira pessoa e resulta em um movimento de câmera intuitivo e correto.